### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-buffer-lightening
+# fluent-plugin-buffer-lightening, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd buffer plugin on memory to flush with many types of chunk limit methods:
   * events count limit in chunk


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
