### PR TITLE
output_try_flush_interval_patch is no longer needed

### DIFF
--- a/lib/fluent/plugin/buf_lightening.rb
+++ b/lib/fluent/plugin/buf_lightening.rb
@@ -1,5 +1,4 @@
 require 'fluent/plugin/buf_memory'
-require_relative 'output_try_flush_interval_patch'
 
 module Fluent
   class LighteningBufferChunk < MemoryBufferChunk


### PR DESCRIPTION
please see https://github.com/tagomoris/fluent-plugin-bigquery/pull/13.
