### PR TITLE
Adjust current Travis CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3.0
+before_install:
+  - gem install bundler


### PR DESCRIPTION
- Drop Ruby 1.9 support
- Add Ruby 2.1, 2.2, and 2.3.0
- Use latest bundler
